### PR TITLE
Add ruby ci github action

### DIFF
--- a/.github/workflows/ruby-ci.yaml
+++ b/.github/workflows/ruby-ci.yaml
@@ -1,0 +1,31 @@
+name: ThreatExchange Library CI - Ruby
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'ruby/**'
+  pull_request:
+    branches:
+    - master
+    paths:
+    - 'ruby/**'
+
+defaults:
+  run:
+    working-directory: ruby
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake


### PR DESCRIPTION
This action will help with validating PRs to the ruby library by automating install the gem dependencies and running the existing tests for the ruby library.